### PR TITLE
Add CircleCI workflow to push images automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,3 +54,14 @@ workflows:
           context: 
             - gcr-io-stackrox-hub-push
             - docker-io-pull
+  release:
+    jobs:
+      - publish:
+          context: 
+            - gcr-io-stackrox-hub-push
+            - docker-io-pull
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/


### PR DESCRIPTION
See title
Circle CI job:
<img width="1365" alt="Screen Shot 2020-11-18 at 5 31 58 PM" src="https://user-images.githubusercontent.com/6870443/99609061-06d6c780-29c4-11eb-86af-fec4fd316fa2.png">

Uploaded image:
<img width="438" alt="Screen Shot 2020-11-18 at 5 32 05 PM" src="https://user-images.githubusercontent.com/6870443/99609077-10602f80-29c4-11eb-8fcf-c75080495635.png">
