### PR TITLE
ROX-16426 / ROX-14418: Get ENP up and running

### DIFF
--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -20,6 +20,7 @@ on:
 jobs:
   save-current-networks:
     name: Download and store currently published latest networks
+    if:  github.event_name == 'schedule' || (github.event.inputs.dry-run == 'false' && github.event_name == 'workflow_dispatch') # Can only be triggered by scheduled run or manual action with dry-run set to false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -94,10 +95,10 @@ jobs:
         run:  linux/network-crawler --dry-run --bucket-name definitions.stackrox.io
 
   run-and-upload:
+    name: Run external-network-pusher and upload results
     if:  github.event_name == 'schedule' || (github.event.inputs.dry-run == 'false' && github.event_name == 'workflow_dispatch') # Can only be triggered by scheduled run or manual action with dry-run set to false
     runs-on: ubuntu-latest
     needs: [build, save-current-networks]
-    name: Run external-network-pusher and upload results
     steps:
       - uses: 'google-github-actions/auth@v1'
         with:

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -55,7 +55,7 @@ jobs:
           name: bin
           path: .gobin
 
-  run-dry-run:
+  run-dry-run: # Dry run will run on PRs by default
     runs-on: ubuntu-latest
     needs: build
     name: Dry-run external-network-pusher and simulate results
@@ -76,7 +76,7 @@ jobs:
       - name: Set permissions to file
         run:  chmod +x linux/network-crawler
       
-      - name: Run external-network-pusher
+      - name: Dry run external-network-pusher
         run:  linux/network-crawler --dry-run --bucket-name definitions.stackrox.io
         continue-on-error: false
 

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -65,8 +65,6 @@ jobs:
           credentials_json: '${{ secrets.GCP_NETWORKS_UPLOADER_SA }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
-        with:
-          install_components: "gke-gcloud-auth-plugin"
 
       - name: Download executable
         uses: actions/download-artifact@v3
@@ -91,8 +89,6 @@ jobs:
           credentials_json: '${{ secrets.GCP_NETWORKS_UPLOADER_SA }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
-        with:
-          install_components: "gke-gcloud-auth-plugin"
 
       - name: Download executable
         uses: actions/download-artifact@v3

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -115,7 +115,7 @@ jobs:
         run:  chmod +x linux/network-crawler
       
       - name: Run external-network-pusher
-        run:  linux/network-crawler --dry-run --bucket-name definitions.stackrox.io  # FIXME: Remove dry-run flag here
+        run:  linux/network-crawler --bucket-name definitions.stackrox.io
 
   notify:
     name: Notify about failed run

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -1,9 +1,20 @@
 name: Build external-network-pusher
 
 on:
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
   schedule:
     - cron: 30 10 * * * # Run this every day at 10:30 UTC
   workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Execute Dry Run
+        required: false
+        default: true
+        type: boolean
 
 
 jobs:
@@ -44,8 +55,33 @@ jobs:
           name: bin
           path: .gobin
 
+  run-dry-run:
+    runs-on: ubuntu-latest
+    needs: build
+    name: Dry-run external-network-pusher and simulate results
+    steps:
+      - uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_NETWORKS_UPLOADER_SA }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v0'
+        with:
+          install_components: "gke-gcloud-auth-plugin"
+
+      - name: Download executable
+        uses: actions/download-artifact@v3
+        with:
+          name: bin
+
+      - name: Set permissions to file
+        run:  chmod +x linux/network-crawler
+      
+      - name: Run external-network-pusher
+        run:  linux/network-crawler --dry-run --bucket-name definitions.stackrox.io
+        continue-on-error: false
 
   run-and-upload:
+    if: github.event.inputs.dry-run != 'true' || github.event_name == 'schedule' # Can only be triggered by scheduled run or manual action with dry-run set to false
     runs-on: ubuntu-latest
     needs: build
     name: Run external-network-pusher and upload results
@@ -67,5 +103,5 @@ jobs:
         run:  chmod +x linux/network-crawler
       
       - name: Run external-network-pusher
-        run:  linux/network-crawler --dry-run --bucket-name definitions.stackrox.io
+        run:  linux/network-crawler --dry-run --bucket-name definitions.stackrox.io  # FIXME: Remove dry-run flag here
         continue-on-error: false

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -22,8 +22,10 @@ jobs:
     name: Download and store currently published latest networks
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: Download and test latest networks 
-        run: /repos/${{ github.repository }}/contents/.github/workflows/scripts/download-current-networks.sh
+        run: ${GITHUB_WORKSPACE}/.github/workflows/scripts/download-current-networks.sh
         shell: bash
       
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -1,4 +1,4 @@
-name: Build external-network-pusher
+name: Update external networks
 
 on:
   pull_request:

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download and test latest networks 
-        run: ${GITHUB_WORKSPACE}/.github/workflows/scripts/download-current-networks.sh
+        run: ./.github/workflows/scripts/download-current-networks.sh
         shell: bash
       
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.GCP_RELEASE_AUTOMATION_SA }}'
+          credentials_json: '${{ secrets.GCP_NETWORKS_UPLOADER_SA }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'
         with:

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -116,3 +116,29 @@ jobs:
       
       - name: Run external-network-pusher
         run:  linux/network-crawler --dry-run --bucket-name definitions.stackrox.io  # FIXME: Remove dry-run flag here
+
+  notify:
+    name: Notify about failed run
+    if: failure()
+    needs: run-and-upload
+    runs-on: ubuntu-latest
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    steps:
+      - name: Post to Slack channel team-acs-maple-interruptions
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: "C03SWCX9W0Z"
+          payload: >-
+            { "blocks": [
+
+            { "type": "section", "text": { "type": "mrkdwn", "text":
+            ":red-warning: Daily update of external networks for defintions.stackrox.io failed! :red-warning:\nRefer to the Workflow logs for more information."}},
+
+            { "type": "divider" },
+
+            { "type": "section", "text": { "type": "mrkdwn", "text":
+            ">
+            Repository: <${{github.server_url}}/${{github.repository}}|${{github.repository}}>\n>
+            Workflow: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.workflow}}>" }}
+            ]}

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -119,7 +119,7 @@ jobs:
 
   notify:
     name: Notify about failed run
-    # if: failure()
+    if: failure()
     needs: run-and-upload
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -119,7 +119,7 @@ jobs:
 
   notify:
     name: Notify about failed run
-    if: failure()
+    # if: failure()
     needs: run-and-upload
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -81,7 +81,7 @@ jobs:
         continue-on-error: false
 
   run-and-upload:
-    if: github.event.inputs.dry-run != 'true' || github.event_name == 'schedule' # Can only be triggered by scheduled run or manual action with dry-run set to false
+    if:  github.event_name == 'schedule' || (github.event.inputs.dry-run == 'false' && github.event_name == 'workflow_dispatch') # Can only be triggered by scheduled run or manual action with dry-run set to false
     runs-on: ubuntu-latest
     needs: build
     name: Run external-network-pusher and upload results

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -2,12 +2,12 @@ name: Build external-network-pusher
 
 on:
   schedule:
-    - cron: 30 19 * * * # Run this every day at 19:30 UTC
+    - cron: 30 10 * * * # Run this every day at 10:30 UTC
   workflow_dispatch:
 
 
 jobs:
-  build-and-upload:
+  build:
     name: Build external-network-pusher
     runs-on: ubuntu-latest
     steps:
@@ -47,9 +47,16 @@ jobs:
 
   run-and-upload:
     runs-on: ubuntu-latest
-    needs: build-and-upload
+    needs: build
     name: Run external-network-pusher and upload results
     steps:
+      - uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_RELEASE_AUTOMATION_SA }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v0'
+        with:
+          install_components: "gke-gcloud-auth-plugin"
 
       - name: Download executable
         uses: actions/download-artifact@v3
@@ -60,7 +67,5 @@ jobs:
         run:  chmod +x linux/network-crawler
       
       - name: Run external-network-pusher
-        run:  linux/network-crawler --dry-run --bucket-name 123
+        run:  linux/network-crawler --dry-run --bucket-name definitions.stackrox.io
         continue-on-error: false
-
-

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download and test latest networks 
-        run: ./.github/workflows/scripts/download-current-networks.sh
+        run: /repos/${{ github.repository }}/contents/.github/workflows/scripts/download-current-networks.sh
         shell: bash
       
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/push-networks.yaml
+++ b/.github/workflows/push-networks.yaml
@@ -18,6 +18,20 @@ on:
 
 
 jobs:
+  save-current-networks:
+    name: Download and store currently published latest networks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download and test latest networks 
+        run: ${GITHUB_WORKSPACE}/.github/workflows/scripts/download-current-networks.sh
+        shell: bash
+      
+      - uses: actions/upload-artifact@v3
+        with:
+          name: current-latest-networks
+          path: /tmp/external-networks
+
+
   build:
     name: Build external-network-pusher
     runs-on: ubuntu-latest
@@ -76,12 +90,11 @@ jobs:
       
       - name: Dry run external-network-pusher
         run:  linux/network-crawler --dry-run --bucket-name definitions.stackrox.io
-        continue-on-error: false
 
   run-and-upload:
     if:  github.event_name == 'schedule' || (github.event.inputs.dry-run == 'false' && github.event_name == 'workflow_dispatch') # Can only be triggered by scheduled run or manual action with dry-run set to false
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, save-current-networks]
     name: Run external-network-pusher and upload results
     steps:
       - uses: 'google-github-actions/auth@v1'
@@ -100,4 +113,3 @@ jobs:
       
       - name: Run external-network-pusher
         run:  linux/network-crawler --dry-run --bucket-name definitions.stackrox.io  # FIXME: Remove dry-run flag here
-        continue-on-error: false

--- a/.github/workflows/scripts/download-current-networks.sh
+++ b/.github/workflows/scripts/download-current-networks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Fetches the current latest networks before updating them through the external networks pusher
+
+set -euo pipefail
+
+mkdir -p /tmp/external-networks
+latest_prefix="$(wget -q https://definitions.stackrox.io/external-networks/latest_prefix -O -)"
+wget -O /tmp/external-networks/checksum "https://definitions.stackrox.io/${latest_prefix}/checksum"
+wget -O /tmp/external-networks/networks "https://definitions.stackrox.io/${latest_prefix}/networks"
+test -s /tmp/external-networks/checksum
+test -s /tmp/external-networks/networks


### PR DESCRIPTION
~~FIXME: After review, before merging, remove the `dry-run` flag from the production `run-and-upload` step [here](https://github.com/stackrox/external-network-pusher/pull/24/files#diff-920dae94a370229ec0d6613197b3d00e75ed7942250e00ff40d6414d48f61195R106).~~

This PR updates and extends the workflow.
It introduces two separate steps as follow ups to the build step:
- `run-dry-run`: Runs the binary in dry-run mode. This will automatically run on PRs and can be manually triggered on the "Actions" tab 
- `run-and-upload`: Runs the binary in production mode where it writes to the GCP bucket `defitions.stackrox.io`. This will be run daily on 10.30 AM UTC and can also be triggered manually on the "Actions" tab (by unchecking the dry run option)

Additionally, it will send a notification to a Team Maple Slack channel if the scheduled run failed.