### PR TITLE
remove tom from reviewers of go.mod

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,4 +17,3 @@ updates:
     open-pull-requests-limit: 3
     reviewers:
       - "Maddosaurus"
-      - "tommartensen"


### PR DESCRIPTION
I don't have the context to decide about the dependabot go.mod alerts for this repository.
Happy stay as reviewer for GHA. 