### PR TITLE
Chore: Set dependabot to tag Maple for reviews

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,8 +4,7 @@ updates:
     directory: "/"
     open-pull-requests-limit: 3
     reviewers:
-      - "Maddosaurus"
-      - "tommartensen"
+      - 'stackrox/maple'
     schedule:
       interval: 'weekly'
       day: 'wednesday'


### PR DESCRIPTION
Update reviewers for Dependabot from persons to team/Maple