### PR TITLE
chore: Set Maple as Dependabot reviewers

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,4 +15,4 @@ updates:
       day: 'wednesday'
     open-pull-requests-limit: 3
     reviewers:
-      - "Maddosaurus"
+      - 'stackrox/maple'


### PR DESCRIPTION
Ensure all of team Maple get the notification for Dependabot reviews