### PR TITLE
chore(logs): Add logging output to separate processing phases

### DIFF
--- a/cmd/network-crawler/network-crawler.go
+++ b/cmd/network-crawler/network-crawler.go
@@ -145,12 +145,17 @@ func publishExternalNetworks(
 
 		log.Printf("Successfully crawled provider %s", crawler.GetHumanReadableProviderName())
 	}
+	log.Print("Finished crawling all providers.")
 
+	log.Print("=======")
+	log.Print("Validating crawl results...")
 	err = validateExternalNetworks(crawlerImpls, &allExternalNetworks)
 	if err != nil {
 		return errors.Wrap(err, "external network sources validation failed")
 	}
 
+	log.Print("=======")
+	log.Print("Uploading external networks...")
 	// Create and upload the object file
 	err = uploadExternalNetworkSources(
 		&allExternalNetworks,
@@ -164,7 +169,7 @@ func publishExternalNetworks(
 		return errors.Wrap(err, "failed to upload data to bucket")
 	}
 
-	log.Print("Finished crawling all providers.")
+	log.Print("Processing done.")
 	return nil
 }
 


### PR DESCRIPTION
The reason for that change is that the log reads like the failure would be in crawling, however, the crawler has finished, but the validation is failing. 

Example from https://github.com/stackrox/external-network-pusher/actions/runs/9527464210/job/26264108918#step:6:38
```
2024/06/15 10:36:23 Dry run specified. Instead of uploading the content to bucket will just print to stdout.
2024/06/15 10:36:23 Crawling from this list of providers: Google Cloud, Microsoft Azure Cloud, Amazon, Oracle Cloud Platform, Cloudflare
2024/06/15 10:36:23 =======
2024/06/15 10:36:23 Crawing from provider Google Cloud...
2024/06/15 10:36:23 Getting from URL: https://www.gstatic.com/ipranges/cloud.json...
[20](https://github.com/stackrox/external-network-pusher/actions/runs/9527464210/job/26264093017#step:6:21)24/06/15 10:36:24 Successfully crawled provider Google Cloud
2024/06/15 10:36:24 =======
2024/06/15 10:36:24 Crawing from provider Microsoft Azure Cloud...
2024/06/15 10:36:30 Successfully crawled provider Microsoft Azure Cloud
20[24](https://github.com/stackrox/external-network-pusher/actions/runs/9527464210/job/26264093017#step:6:25)/06/15 10:36:30 =======
2024/06/15 10:36:30 Crawing from provider Amazon...
2024/06/15 10:36:30 Getting from URL: https://ip-ranges.amazonaws.com/ip-ranges.json...
2024/06/15 10:36:30 Successfully crawled provider Amazon
2024/06/15 10:36:30 =======
2024/06/15 10:36:30 Crawing from provider Oracle Cloud Platform...
2024/06/15 10:36:[30](https://github.com/stackrox/external-network-pusher/actions/runs/9527464210/job/26264093017#step:6:31) Getting from URL: https://docs.cloud.oracle.com/en-us/iaas/tools/public_ip_ranges.json...
2024/06/15 10:36:[31](https://github.com/stackrox/external-network-pusher/actions/runs/9527464210/job/26264093017#step:6:32) Successfully crawled provider Oracle Cloud Platform
2024/06/15 10:36:31 =======
2024/06/15 10:36:31 Crawing from provider Cloudflare...
2024/06/15 10:36:31 Getting from URL: https://api.cloudflare.com/client/v4/ips...
2024/06/15 10:36:31 Successfully crawled provider Cloudflare
2024/06/15 10:[36](https://github.com/stackrox/external-network-pusher/actions/runs/9527464210/job/26264093017#step:6:37):31 External network pusher failed: failed publishing external network ranges: external network sources validation failed: provider Azure does not have any region associated with it
```