### PR TITLE
fix(azure): Fix error handling in the azure crawler

### DIFF
--- a/pkg/crawlers/azure/azure.go
+++ b/pkg/crawlers/azure/azure.go
@@ -279,8 +279,11 @@ func (c *azureNetworkCrawler) fetchAll() ([][]byte, error) {
 	jsonURLs := make([]string, 0, len(c.urls))
 	for _, url := range c.urls {
 		jsonURL, err := c.redirectToJSONURL(url)
-		if err != nil || jsonURL == "" {
+		if err != nil {
 			return nil, errors.Wrapf(err, "failed to crawl Azure with URL: %s. Error: %v. JSON URL: %s", url, err, jsonURL)
+		}
+		if jsonURL == "" {
+			return nil, errors.Errorf("failed to crawl Azure with URL: %s, empty JSON URL returned. This could indicate Azure's services are unavailable", url)
 		}
 		log.Printf("Received Azure network JSON URL: %s", jsonURL)
 		jsonURLs = append(jsonURLs, jsonURL)


### PR DESCRIPTION
The results of `redirectToJSONURL` were not handled properly because `errors.Wrapf` will return nil if the error that is being wrapped is nil. In order to properly handle the case where `err` is nil but `jsonURL` is empty we need to split the if.